### PR TITLE
Add support for jsonv2 from Go1.25.0

### DIFF
--- a/internal/server/pause_controller.go
+++ b/internal/server/pause_controller.go
@@ -49,8 +49,8 @@ func NewPauseController() *PauseController {
 }
 
 func (p *PauseController) UnmarshalJSON(data []byte) error {
-	type alias *PauseController // Avoid infinite recursion when we call Unmarshal
-	err := json.Unmarshal(data, alias(p))
+	type alias PauseController // Avoid infinite recursion when we call Unmarshal
+	err := json.Unmarshal(data, (*alias)(p))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The jsonv2 package has different behavior in resolving Marshaler/Unmarshaler interfaces. 
The pause controller has to be updated.